### PR TITLE
Update S3 bucket default to lowercase

### DIFF
--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -167,5 +167,5 @@ variable "private_instance_name" {
 variable "s3_bucket_name" {
   description = "Name for the S3 bucket"
   type        = string
-  default     = "S3-bucket-ew1-blueprint-ecs"
+  default     = "s3-bucket-ew1-blueprint-ecs"
 }


### PR DESCRIPTION
## Summary
- set the S3 bucket name default to lowercase

## Testing
- `terraform fmt -check -diff Terraform/variables.tf` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684227394c78833382e42cef10839c3a